### PR TITLE
Expose 'size_t' type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ In addition to the basic types, there are type aliases for common C types.
     ulong		unsigned long
     longlong	long long
     ulonglong	unsigned long long
+    size_t      unsigned int (size is platform-dependent)
 
 # LICENSE
 

--- a/lib/ffi.js
+++ b/lib/ffi.js
@@ -48,7 +48,8 @@ FFI.NON_SPECIFIC_TYPES = {
     "long":       "Long",
     "ulong":      "ULong",
     "longlong":   "LongLong",
-    "ulonglong":  "ULongLong"
+    "ulonglong":  "ULongLong",
+    "size_t":     "SizeT"
 };
 
 // The initial buffer size of string arguments

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,9 @@ assert.equal(16, ptr.getLongLong());
 ptr.putULongLong(17);
 assert.equal(17, ptr.getULongLong());
 
+ptr.putSizeT(18);
+assert.equal(18, ptr.getSizeT());
+
 //////////////////////
 
 var nullptr = new Pointer(0);


### PR DESCRIPTION
A lot of the functions in libc have parameters of type size_t (an example is gethostname(3)), so it makes sense to expose this type.
