### PR TITLE
Fix unsigned methodCallSuffixForType

### DIFF
--- a/lib/pointer.js
+++ b/lib/pointer.js
@@ -53,7 +53,7 @@ Pointer.methodCallSuffixForType = function(typeDef) {
             // no hard mapping, so try to use size
             var sz      = FFI.sizeOf(typeDef),
                 szMap   = FFI.SIZE_TO_POINTER_METHOD_MAP[sz],
-                signed  = (typeDef != "byte" || typeDef.substr(0, 1) == "u");
+                signed  = (typeDef != "byte" && typeDef != "size_t" && typeDef.substr(0, 1) != "u");
             
             if (sz) {
                 // XXX: This is kind of a shitty way to detect unsigned/signed


### PR DESCRIPTION
Before this fix, here are the type mappings:

```
binding:  Byte  ->  UInt8
binding:  Char  ->  Int8
binding:  UChar  ->  Int8
binding:  Short  ->  Int16
binding:  UShort  ->  Int16
binding:  Int  ->  Int32
binding:  UInt  ->  Int32
binding:  Long  ->  Int64
binding:  ULong  ->  Int64
binding:  LongLong  ->  Int64
binding:  ULongLong  ->  Int64
```

And after the fix:

```
binding:  Byte  ->  UInt8
binding:  Char  ->  Int8
binding:  UChar  ->  UInt8
binding:  Short  ->  Int16
binding:  UShort  ->  UInt16
binding:  Int  ->  Int32
binding:  UInt  ->  UInt32
binding:  Long  ->  Int64
binding:  ULong  ->  UInt64
binding:  LongLong  ->  Int64
binding:  ULongLong  ->  UInt64
```
