### PR TITLE
Handle linker scripts

### DIFF
--- a/lib/dynamic_library.js
+++ b/lib/dynamic_library.js
@@ -5,7 +5,34 @@ var DynamicLibrary = module.exports = function(path, mode) {
     this._handle = this._dlopen(path, mode || DynamicLibrary.FLAGS.RTLD_NOW);
 
     if (this._handle.isNull()) {
-        throw new Error("Dynamic Linking Error: " + this._dlerror());
+        var err = this._dlerror();
+
+        // THIS CODE IS BASED ON GHC Trac ticket #2615
+        // http://hackage.haskell.org/trac/ghc/attachment/ticket/2615
+
+        // On some systems (e.g., Gentoo Linux) dynamic files (e.g. libc.so)
+        // contain linker scripts rather than ELF-format object code. This
+        // code handles the situation by recognizing the real object code
+        // file name given in the linker script.
+
+        // If an "invalid ELF header" error occurs, it is assumed that the
+        // .so file contains a linker script instead of ELF object code.
+        // In this case, the code looks for the GROUP ( ... ) linker
+        // directive. If one is found, the first file name inside the
+        // parentheses is treated as the name of a dynamic library and the
+        // code attempts to dlopen that file. If this is also unsuccessful,
+        // an error message is returned.
+
+        // see if the error message is due to an invalid ELF header
+        var match;
+        if (match = err.match(/^(([^ \t()])+\.so([^ \t:()])*):([ \t])*invalid ELF header$/)) {
+            var content = require("fs").readFileSync(match[1], 'ascii');
+            // try to find a GROUP ( ... ) command
+            if (match = content.match(/GROUP *\( *(([^ )])+)/)){
+              return DynamicLibrary.call(this, match[1], mode);
+            }
+        }
+        throw new Error("Dynamic Linking Error: " + err);
     }
 };
 


### PR DESCRIPTION
On some OSes (such as Ubuntu linux), a .so file can contain a linker script which will point to the correct shared library to use. This will cause dlopen to raise an error.

As an example, here is what `/usr/lib/libc.so` looks like on Ubuntu 10.04:

```
/* GNU ld script
   Use the shared library, but some functions are only in
   the static library, so try that secondarily.  */
OUTPUT_FORMAT(elf64-x86-64)
GROUP ( /lib/libc.so.6 /usr/lib/libc_nonshared.a  AS_NEEDED ( /lib/ld-linux-x86-64.so.2 ) )
```

I found this Haskell GHC ticket from when they ran into the same problem: http://hackage.haskell.org/trac/ghc/ticket/2615 . I ported their solution to node-ffi (basically, see if the error message is "invalid ELF header" and then try to read the file and look for the GROUP section).
