### PR TITLE
fix a few typos that break with shared libev

### DIFF
--- a/src/callback_info.cc
+++ b/src/callback_info.cc
@@ -56,7 +56,7 @@ void CallbackInfo::Initialize(Handle<Object> target)
     
     // initialize our threaded invokation stuff
     g_mainthread = pthread_self();
-    ev_async_init(EV_DEFAULT_UC_ &g_async, CallbackInfo::WatcherCallback);
+    ev_async_init(&g_async, CallbackInfo::WatcherCallback);
     pthread_mutex_init(&g_queue_mutex, NULL);
     ev_async_start(EV_DEFAULT_UC_ &g_async);
     ev_unref(EV_DEFAULT_UC); // allow the event loop to exit while this is running

--- a/src/threaded_callback_invokation.cc
+++ b/src/threaded_callback_invokation.cc
@@ -8,12 +8,12 @@ ThreadedCallbackInvokation::ThreadedCallbackInvokation(CallbackInfo *cbinfo, voi
     
     pthread_mutex_init(&m_mutex, NULL);
     pthread_cond_init(&m_cond, NULL);
-    ev_ref(EV_DEFAULT_UC_); // hold the event loop open while this is executing
+    ev_ref(EV_DEFAULT_UC); // hold the event loop open while this is executing
 }
 
 ThreadedCallbackInvokation::~ThreadedCallbackInvokation()
 {
-    ev_unref(EV_DEFAULT_UC_);
+    ev_unref(EV_DEFAULT_UC);
     pthread_cond_destroy(&m_cond);
     pthread_mutex_destroy(&m_mutex);
 }


### PR DESCRIPTION
These typos worked fine when EV_MULTIPLICITY=0 (because they compile to
no-ops), but not when EV_MULTIPLICITY=1 (such as when using a shared libev).
