### PR TITLE
User defined search path for library loading

### DIFF
--- a/lib/dynamic_library.js
+++ b/lib/dynamic_library.js
@@ -4,6 +4,7 @@ var ffi = require('./ffi')
   , bindings = require('./bindings')
   , ref = require('ref')
   , read  = require('fs').readFileSync
+  , _path = require('path')
 
 var int = ref.types.int
   , charPtr = ref.refType(ref.types.char)
@@ -22,27 +23,50 @@ var dlopen = ffi.ForeignFunction(bindings.StaticFunctions.dlopen, voidPtr, [ cha
  * turn the pointer into a callable function with `ForeignFunction`.
  */
 
-function DynamicLibrary (path, mode) {
+function DynamicLibrary (path, opts, mode) {
   if (!(this instanceof DynamicLibrary)) {
-    return new DynamicLibrary(path, mode)
+    return new DynamicLibrary(path, opts, mode)
   }
 
-  debug('new DynamicLibrary()', path, mode)
+  debug('new DynamicLibrary()', path, opts, mode)
 
-  if (typeof path === 'string') {
-    path = ref.allocCString(path)
-  } else if (!path) {
-    path = ref.NULL
+  if (opts && !mode) {
+    mode = opts
+    opts = {}
   }
 
   if (typeof mode === 'undefined') {
     mode = DynamicLibrary.FLAGS.RTLD_NOW
   }
 
-  assert(Buffer.isBuffer(path))
   assert.equal('number', typeof mode)
 
-  this._handle = dlopen(path, mode)
+  if (!path) {
+    this._handle = dlopen(ref.NULL, mode)
+  } else {
+    var search_path = opts.search_path || []
+      , tmp_path
+
+    for (i in search_path) {
+      tmp_path = _path.join(search_path[i], path)
+      debug('Searching', tmp_path)
+
+      tmp_path = ref.allocCString(tmp_path)
+      assert(Buffer.isBuffer(tmp_path))
+
+      this._handle = dlopen(tmp_path, mode)
+      assert(Buffer.isBuffer(this._handle),
+        'expected a Buffer instance to be returned from `dlopen()`')
+
+      if (!this._handle.isNull()) {
+        break;
+      }
+    }
+
+    if (this._handle.isNull()) {
+      this._handle = dlopen(ref.allocCString(path), mode)
+    }
+  }
 
   assert(Buffer.isBuffer(this._handle), 'expected a Buffer instance to be returned from `dlopen()`')
 

--- a/lib/library.js
+++ b/lib/library.js
@@ -9,7 +9,7 @@ var ffi = require('./ffi')
  * ForeignFunction.
  */
 
-function Library (libfile, funcs) {
+function Library (libfile, opts, funcs) {
   debug('creating Library object for', libfile)
 
   if (libfile && libfile.indexOf(EXT) === -1) {
@@ -17,8 +17,13 @@ function Library (libfile, funcs) {
     libfile += EXT
   }
 
+  if (!funcs) {
+    funcs = opts;
+    opts = {};
+  }
+
   var lib = {}
-  var dl = new ffi.DynamicLibrary(libfile || null, RTLD_NOW)
+  var dl = new ffi.DynamicLibrary(libfile || null, opts, RTLD_NOW)
 
   Object.keys(funcs || {}).forEach(function (func) {
     debug('defining function', func)


### PR DESCRIPTION
Extends `Library` and `DynamicLibrary` to add an options arg that allows the user
to specify a search_path from which libraries are attempted to be loaded before
the system search path is tried.

This idea came from my experience with libtool/ltdl which allows runtime configured
search paths and without having to shim the library loading path before node is run
