### PR TITLE
add TypeDef to allow for runtime type checking

### DIFF
--- a/lib/_foreign_function.js
+++ b/lib/_foreign_function.js
@@ -46,6 +46,11 @@ function ForeignFunction (cif, funcPtr, returnType, argTypes) {
       var argType = argTypes[i]
         , val = arguments[i]
 
+      if (argType.typedef) {
+        assert.strictEqual(val.type, argType,
+          'Argument ' + i + ' is not the right type')
+      }
+
       var valPtr
       if (val && typeof val.ref === 'function') {
         debug('using the "ref()" function for argument at index', i)
@@ -90,6 +95,11 @@ function ForeignFunction (cif, funcPtr, returnType, argTypes) {
     for (var i = 0; i < numArgs; i++) {
       var argType = argTypes[i]
       var val = arguments[i]
+
+      if (argType.typedef) {
+        assert.strictEqual(argType, val.type,
+          'Argument ' + i + ' is not the right type');
+      }
 
       var valPtr
       if (val && typeof val.ref === 'function') {

--- a/lib/ffi.js
+++ b/lib/ffi.js
@@ -79,6 +79,7 @@ exports.Library = require('./library')
 exports.Callback = require('./callback')
 exports.errno = require('./errno')
 exports.ffiType = require('./type')
+exports.TypeDef = require('./typedef')
 
 // the shared library extension for this platform
 exports.LIB_EXT = exports.Library.EXT

--- a/lib/typedef.js
+++ b/lib/typedef.js
@@ -1,0 +1,31 @@
+var ref = require('ref')
+
+var voidPtr = ref.refType(ref.types.void);
+
+var TypeDef = function (_type, _name) {
+  var type, rtn;
+
+  if (_type.indirection === 1)
+    type = _type
+  else
+    type = voidPtr
+
+  rtn = {
+    indirection: type.indirection,
+    size: type.size,
+    get: type.get,
+    set: type.set,
+    alignment: type.alignment,
+    name: _name || type.name,
+    typedef: true,
+  }
+
+  rtn.cast = function (val) {
+    val.type = rtn
+    return val
+  }
+
+  return rtn;
+};
+
+module.exports = TypeDef

--- a/test/typedef.js
+++ b/test/typedef.js
@@ -1,0 +1,35 @@
+var expect = require('expect.js')
+  , assert = require('assert')
+  , ref = require('ref')
+  , ffi = require('../')
+  , bindings = require('bindings')({ module_root: __dirname, bindings: 'ffi_tests' })
+
+describe('TypeDef', function () {
+
+  afterEach(gc)
+
+  it('should assert on improper type', function () {
+    var myType = ffi.TypeDef(ref.refType(ref.types.void))
+
+    var sprintfGen = ffi.VariadicForeignFunction(bindings.sprintf,
+      ref.types.int32, [ ref.refType(ref.types.void), ref.types.CString ])
+
+    var buf = new Buffer(100)
+
+    var instance = ref.alloc(ref.refType(ref.types.void))
+
+    var sprintf = sprintfGen(myType)
+
+    var expectedAssert;
+
+    assert.throws(function () {
+      sprintf(buf, '%p', instance)
+    }, /AssertionError: Argument 2 is not the right type/);
+
+    assert.doesNotThrow(function () {
+      sprintf(buf, '%p', myType.cast(instance))
+    })
+
+    assert.equal(parseInt(buf.readCString()), instance.address())
+  }) 
+})


### PR DESCRIPTION
This is an idea I've been kicking around to let users more aggressively check at runtime that the right argument types are being passed. Specifically trying to handle the opaque pointer situation, though theoretically can be used with any type.

I decided to make it an alternate path such that users who don't want more overhead don't have to use it.

``` javascript
var myType = TypeDef(ref.refType(ref.types.void))

var func = ffi.ForeignFunction(somefunc, ref.types.void, [myType])

var instance = ref.alloc(ref.refType(ref.types.void))

// will throw
func(instance)

// will succeed
func(myType.cast(instance))

```
