### PR TITLE
Fix binary compatibility of 0.5 branch with node v0.10.x

### DIFF
--- a/src/foreign_caller.cc
+++ b/src/foreign_caller.cc
@@ -78,7 +78,7 @@ Handle<Value> ForeignCaller::Exec(const Arguments& args) {
 
     uv_work_t *req = new uv_work_t;
     req->data = p;
-    uv_queue_work(uv_default_loop(), req, ForeignCaller::AsyncFFICall, ForeignCaller::FinishAsyncFFICall);
+    uv_queue_work(uv_default_loop(), req, ForeignCaller::AsyncFFICall, (uv_after_work_cb)ForeignCaller::FinishAsyncFFICall);
 
     return scope.Close(p->emitter);
   } else {


### PR DESCRIPTION
The 0.5 branch of this node-ffi project is still up on npm with its own alias as `node-ffi`, which exposes the 0.x API.  Several projects, notably NodObjC are still dependent on this older API.  I agree that they should ideally move to the newer 1.x API, but in the meantime, this should get everyone going.
