### PR TITLE
Adding suport for interfacing with global variables in native libraries

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -8,6 +8,7 @@ var DynamicLibrary = require('./dynamic_library')
   , VariadicForeignFunction = require('./foreign_function_var')
   , debug = require('debug')('ffi:Library')
   , RTLD_NOW = DynamicLibrary.FLAGS.RTLD_NOW
+  , ref = require('ref')
 
 /**
  * The extension to use on libraries.
@@ -66,7 +67,8 @@ function Library (libfile, funcs, lib) {
       lib[func] = VariadicForeignFunction(fptr, resultType, paramTypes, abi)
     } else {
       if(paramTypes === undefined) {
-        lib[func] = fptr
+		fptr.type = ref.refType(resultType);
+        lib[func] = fptr;
       }
       else {
         var ff = ForeignFunction(fptr, resultType, paramTypes, abi)

--- a/lib/library.js
+++ b/lib/library.js
@@ -65,8 +65,13 @@ function Library (libfile, funcs, lib) {
     if (varargs) {
       lib[func] = VariadicForeignFunction(fptr, resultType, paramTypes, abi)
     } else {
-      var ff = ForeignFunction(fptr, resultType, paramTypes, abi)
-      lib[func] = async ? ff.async : ff
+      if(paramTypes === undefined) {
+        lib[func] = fptr
+      }
+      else {
+        var ff = ForeignFunction(fptr, resultType, paramTypes, abi)
+        lib[func] = async ? ff.async : ff 
+      }
     }
   })
 


### PR DESCRIPTION
Problem: Some libraries not only export functions, they also export variables. Current implementation doesn't support
 a way to access global variables in native libraries.

Solution: Introduce new syntax that allows creation of bindings to global variables in native libraries. It should be specified only type of variable in ffi.Library object.

Example:
===

```
var library = ffi.Library("somelib", {
   "somelib_var1": [int],
   "somelib_func1": [int, [ref.types.void]]
});
```