### PR TITLE
change Node.js versions used on Travis CI for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
-  - 0.9
-  - 0.10
+  - "0.6"
+  - "0.8"
+  - "0.10"
 
 notifications:
   irc:


### PR DESCRIPTION
Rationale:
- Node.js v0.9 is no longer supported by Travis CI ([example](https://travis-ci.org/rbranson/node-ffi/jobs/24845896)) and thus it has to be dropped.
- Node.js versions are actually strings (e.g. `"0.10"` is not equal to `0.1`).
