### PR TITLE
Reflect the fact that the build fails for node <= 0.8 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "homepage": "http://github.com/node-ffi/node-ffi",
   "engines": {
-    "node": ">=0.6.0"
+    "node": ">=0.10.0"
   },
   "main": "./lib/ffi",
   "dependencies": {


### PR DESCRIPTION
Since `uv_cond_t` is not available in node <= 0.8, `ffi` cannot be compiled for these versions