### PR TITLE
Added basic GetLastError() support

### DIFF
--- a/lib/ffi.js
+++ b/lib/ffi.js
@@ -19,7 +19,7 @@ var bindings = require('./bindings')
 , 'FFI_WIN64', 'FFI_VFP', 'FFI_STDCALL', 'FFI_THISCALL', 'FFI_FASTCALL'
 , 'RTLD_LAZY', 'RTLD_NOW', 'RTLD_LOCAL', 'RTLD_GLOBAL', 'RTLD_NOLOAD'
 , 'RTLD_NODELETE', 'RTLD_FIRST', 'RTLD_NEXT', 'RTLD_DEFAULT', 'RTLD_SELF'
-, 'RTLD_MAIN_ONLY', 'FFI_MS_CDECL'].forEach(function (prop) {
+, 'RTLD_MAIN_ONLY', 'FFI_MS_CDECL', 'win32ErrNo'].forEach(function (prop) {
   if (!bindings.hasOwnProperty(prop)) {
     return debug('skipping exporting of non-existant property', prop)
   }

--- a/src/ffi.cc
+++ b/src/ffi.cc
@@ -2,6 +2,14 @@
 #include <node_buffer.h>
 #include "ffi.h"
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+#ifdef WIN32
+uint32_t g_win32ErrNo = 0;
+#endif
+
 /*
  * Called when the wrapped pointer is garbage collected.
  * We never have to do anything here...
@@ -43,6 +51,10 @@ NAN_MODULE_INIT(FFI::InitializeBindings) {
     Nan::New<FunctionTemplate>(FFICall)->GetFunction());
   Nan::Set(target, Nan::New<String>("ffi_call_async").ToLocalChecked(),
     Nan::New<FunctionTemplate>(FFICallAsync)->GetFunction());
+#ifdef WIN32
+  Nan::Set(target, Nan::New<String>("win32ErrNo").ToLocalChecked(),
+    Nan::New<FunctionTemplate>(Win32ErrNo)->GetFunction());
+#endif
 
   // `ffi_status` enum values
   SET_ENUM_VALUE(FFI_OK);
@@ -266,6 +278,9 @@ NAN_METHOD(FFI::FFICall) {
           (void *)res,
           (void **)fnargs
         );
+#ifdef WIN32
+      g_win32ErrNo = GetLastError();
+#endif
 #if __OBJC__ || __OBJC2__
     } @catch (id ex) {
       return THROW_ERROR_EXCEPTION(WrapPointer((char *)ex));
@@ -371,6 +386,11 @@ void FFI::FinishAsyncFFICall(uv_work_t *req) {
     FatalException(try_catch);
 #endif
   }
+}
+
+NAN_METHOD(FFI::Win32ErrNo) {
+    Nan::HandleScope scope;
+    info.GetReturnValue().Set(Nan::New<Uint32>(g_win32ErrNo));
 }
 
 NAN_MODULE_INIT(init) {

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -76,6 +76,9 @@ class FFI {
     static NAN_METHOD(FFICallAsync);
     static void AsyncFFICall(uv_work_t *req);
     static void FinishAsyncFFICall(uv_work_t *req);
+#ifdef WIN32
+    static NAN_METHOD(Win32ErrNo);
+#endif
 
     static NAN_METHOD(Strtoul);
 };


### PR DESCRIPTION
This is for Windows API calls that use `SetLastError()` or something like that. As for now, you are not able to get this error code, whether by calling `GetLastError()` with node-ffi or by a dedicated little native Node.js addon just for `GetLastError()`.

`win32ErrNo` comes from `errno`.

Please pull this changes or do something similar.

See also:
- http://stackoverflow.com/questions/33564858/getlasterror-with-node-ffi
- https://github.com/node-ffi/node-ffi/issues/261