### PR TITLE
Allow to pass DynamicLibrary to Library func

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -31,18 +31,20 @@ var EXT = Library.EXT = {
  * ForeignFunction.
  */
 
-function Library (libfile, funcs, lib) {
-  debug('creating Library object for', libfile)
+function Library (dl, funcs, lib) {
+  debug('creating Library object for', dl)
 
-  if (libfile && libfile.indexOf(EXT) === -1) {
-    debug('appending library extension to library name', EXT)
-    libfile += EXT
+  if (!(dl instanceof DynamicLibrary)) {
+    if (dl && dl.indexOf(EXT) === -1) {
+      debug('appending library extension to library name', EXT)
+      dl += EXT
+    }
+    dl = new DynamicLibrary(dl || null, RTLD_NOW)
   }
 
   if (!lib) {
     lib = {}
   }
-  var dl = new DynamicLibrary(libfile || null, RTLD_NOW)
 
   Object.keys(funcs || {}).forEach(function (func) {
     debug('defining function', func)
@@ -51,8 +53,7 @@ function Library (libfile, funcs, lib) {
       , info = funcs[func]
 
     if (fptr.isNull()) {
-      throw new Error('Library: "' + libfile
-        + '" returned NULL function pointer for "' + func + '"')
+      throw new Error('Library returned NULL function pointer for "' + func + '"')
     }
 
     var resultType = info[0]


### PR DESCRIPTION
Extend Library API to support DynamicLibrary as first parameter. This might be useful for manual `dlopen` flags setting and nonstandard lib names.

Address #137