### PR TITLE
Add a form of dependant types

### DIFF
--- a/lib/callback.js
+++ b/lib/callback.js
@@ -45,21 +45,40 @@ function Callback (retType, argTypes, abi, func) {
   // normalize the "types" (they could be strings, so turn into real type
   // instances)
   retType = ref.coerceType(retType)
-  argTypes = argTypes.map(ref.coerceType)
+  argTypes = argTypes.map(function(type){ return typeof type !== 'function' ? ref.coerceType(type) : type})
+  // types the require refinement as a first approximation are marshaled as pointers
+  cifArgTypes = argTypes.map(function(type) { return typeof type == 'function' ? ref.coerceType("pointer") : type})
 
   // create the `ffi_cif *` instance
-  var cif = CIF(retType, argTypes, abi)
+  var cif = CIF(retType, cifArgTypes, abi)
   var argc = argTypes.length
 
   var callback = _Callback(cif, retType.size, argc, errorReportCallback, function (retval, params) {
     debug('Callback function being invoked')
     try {
       var args = []
+      var needRefinement = false
       for (var i = 0; i < argc; i++) {
         var type = argTypes[ i ]
-        var argPtr = params.readPointer(i * ref.sizeof.pointer, type.size)
-        argPtr.type = type
-        args.push(argPtr.deref())
+        if(typeof type !== 'function') {
+          var argPtr = params.readPointer(i * ref.sizeof.pointer, type.size)
+          argPtr.type = type
+          args.push(argPtr.deref())
+        }
+        else {
+          args.push(null);
+          needRefinement = true
+        }
+      }
+      if( needRefinement ) {
+        for (var i = 0; i < argc; i++) {
+          var type = argTypes[ i ]
+          if(typeof type === 'function') {
+            var argPtr = params.readPointer(i * ref.sizeof.pointer, type.size)
+            argPtr.type = type.apply(null, args)
+            args[i] = argPtr.deref()
+          }
+        }
       }
 
       // Invoke the user-given function

--- a/test/callback.js
+++ b/test/callback.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
   , ref = require('ref')
+  , array = require('ref-array')
   , ffi = require('../')
   , int = ref.types.int
   , bindings = require('bindings')({ module_root: __dirname, bindings: 'ffi_tests' })
@@ -17,6 +18,19 @@ describe('Callback', function () {
     var funcPtr = ffi.Callback(int, [ int ], Math.abs)
     var func = ffi.ForeignFunction(funcPtr, int, [ int ])
     assert.equal(1234, func(-1234))
+  })
+
+  it('should be possible to marshal variable size array', function () {
+    function refineTypes(ptr, size) {
+      return ref.refType(array(ref.types.uint8, size))
+    }
+    function bytesToString(ptr, size) {
+      return (+ptr.toString());
+    }
+    var funcPtr = ffi.Callback(int, [ refineTypes, int ], bytesToString)
+    var func = ffi.ForeignFunction(funcPtr, int, [ ref.refType(ref.types.uint8), int ])
+    var buf = new Buffer("1234567890")
+    assert.equal(1234567890, func(buf, buf.length))
   })
 
   it('should work with a "void" return type', function () {


### PR DESCRIPTION
Allow for refinement of types based on other argument values. Useful in situations when size of arrays is known only by inspecting other elements. For example consider a callback called from C to JavaScript with this signature:

    void (*write)(char *ptr, size_t size);

To handle it properly use this:

    function cb_write_refine_ptr_type(ptr, size) {
        // here all non-refined values are present, refined ones are nulls
        return ref.refType(array(ref.types.uint8, size))
    }

    function cb_write(ptr, size) {
        // ptr is a Buffer of length size here
    }

Now use the following `Callback` call:

    ffi.Callback(ref.types.void, [
                        cb_write_refine_ptr_type, 
                        ref.types.size_t], cb_write);
