### PR TITLE
test: keep cif structs alive during gc

### DIFF
--- a/test/callback.js
+++ b/test/callback.js
@@ -80,6 +80,7 @@ describe('Callback', function () {
     // should be ok
     bindings.call_cb()
 
+    global.cif = cb._cif
     cb = null // KILL!!
     gc()
 
@@ -276,6 +277,7 @@ describe('Callback', function () {
         })
       })
 
+      global.cif = cb._cif
       cb = null // KILL!!
       gc()
 


### PR DESCRIPTION
Up until now, test/callback.js assumed that the `cb.cif` object
would not be garbage collected and was available to `Callback::Invoke`.

That has never been a valid assumption, but as of
https://github.com/nodejs/node/pull/12141 Buffers created with
`new Buffer(n)` each have their own `ArrayBuffer` which gets
garbage-collected much more easily, which in turn would
crash the test suite here.

To (lazy-)fix this, assign `cb._cif` to some global variable that is
guaranteed to stay alive.