### PR TITLE
add support for exported variables

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -6,6 +6,7 @@
 var DynamicLibrary = require('./dynamic_library')
   , ForeignFunction = require('./foreign_function')
   , VariadicForeignFunction = require('./foreign_function_var')
+  , ref = require('ref')
   , debug = require('debug')('ffi:Library')
   , RTLD_NOW = DynamicLibrary.FLAGS.RTLD_NOW
 
@@ -62,7 +63,11 @@ function Library (libfile, funcs, lib) {
       , async = fopts && fopts.async
       , varargs = fopts && fopts.varargs
 
-    if (varargs) {
+    if (paramTypes === void 0){
+      rettype = ref.coerceType(resultType)
+      lib[func] = fptr.reinterpret(rettype.size, 0)
+      lib[func].type = ref.coerceType(rettype)
+    } else if (varargs) {
       lib[func] = VariadicForeignFunction(fptr, resultType, paramTypes, abi)
     } else {
       var ff = ForeignFunction(fptr, resultType, paramTypes, abi)


### PR DESCRIPTION
If paramTypes is `undefined`, `ref` to exported variable will be returned.
We can acquire value with `deref()`.

```
const libxxx = ffi.Library("libxxx", {"exported_variable": ["int", void 0]})
console.log(libxxx.exported_variable.deref())
```
