### PR TITLE
enable-promise-when-arguments-number-is-proper

### DIFF
--- a/lib/_foreign_function.js
+++ b/lib/_foreign_function.js
@@ -70,9 +70,18 @@ function ForeignFunction (cif, funcPtr, returnType, argTypes) {
     debug('invoking async proxy function')
 
     var argc = arguments.length
+    var argv = arguments
     if (argc !== numArgs + 1) {
-      throw new TypeError('Expected ' + (numArgs + 1) +
+      if (argc == numArgs) {
+        return new Promise(
+          function(callback){
+            return proxy.async(...argv, function(err, ans){return callback(ans)})
+          }
+        )
+      } else {
+        throw new TypeError('Expected ' + (numArgs + 1) +
           ' arguments, got ' + argc)
+      }
     }
 
     var callback = arguments[argc - 1]


### PR DESCRIPTION
example code:

`test.js`:
```
var ffi = require("ffi")
var add = ffi.Library('./libadd.so', {
  'add': ['int', ['int', 'int']]
})

var test = async()=>{
  add.add.async(1,2,(err, ans)=>{console.log(ans)})
  var ans = await add.add.async(1,2)
  console.log(ans);
}

test()
```

`add.c`:
```
int add(int a, int b){
  return a+b;
}

```