### PR TITLE
Update to Nan 2.10 to support Node 9.11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "2",
     "ref": "1",
     "ref-struct": "1",
-    "nan": "2"
+    "nan": "~2.10"
   },
   "devDependencies": {
     "fs-extra": "^0.23.1",

--- a/src/ffi.cc
+++ b/src/ffi.cc
@@ -34,10 +34,10 @@ NAN_MODULE_INIT(FFI::InitializeStaticFunctions) {
 
 ///////////////
 
-#define SET_ENUM_VALUE(_value) \
-  Nan::ForceSet(target, Nan::New<String>(#_value).ToLocalChecked(), \
-  Nan::New<Integer>((uint32_t)_value), \
-  static_cast<PropertyAttribute>(ReadOnly|DontDelete))
+#define SET_ENUM_VALUE(_value)                                               \
+  Nan::DefineOwnProperty(target, Nan::New<String>(#_value).ToLocalChecked(), \
+                         Nan::New<Integer>((uint32_t)_value),                \
+                         static_cast<PropertyAttribute>(ReadOnly | DontDelete))
 
 NAN_MODULE_INIT(FFI::InitializeBindings) {
 
@@ -108,28 +108,28 @@ NAN_MODULE_INIT(FFI::InitializeBindings) {
 
   /* flags for dlsym() */
 #ifdef RTLD_NEXT
-  Nan::ForceSet(target,Nan::New<String>("RTLD_NEXT").ToLocalChecked(), WrapPointer((char *)RTLD_NEXT), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("RTLD_NEXT").ToLocalChecked(), WrapPointer((char *)RTLD_NEXT), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 #endif
 #ifdef RTLD_DEFAULT
-  Nan::ForceSet(target,Nan::New<String>("RTLD_DEFAULT").ToLocalChecked(), WrapPointer((char *)RTLD_DEFAULT), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("RTLD_DEFAULT").ToLocalChecked(), WrapPointer((char *)RTLD_DEFAULT), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 #endif
 #ifdef RTLD_SELF
-  Nan::ForceSet(target,Nan::New<String>("RTLD_SELF").ToLocalChecked(), WrapPointer((char *)RTLD_SELF), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("RTLD_SELF").ToLocalChecked(), WrapPointer((char *)RTLD_SELF), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 #endif
 #ifdef RTLD_MAIN_ONLY
-  Nan::ForceSet(target,Nan::New<String>("RTLD_MAIN_ONLY").ToLocalChecked(), WrapPointer((char *)RTLD_MAIN_ONLY), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("RTLD_MAIN_ONLY").ToLocalChecked(), WrapPointer((char *)RTLD_MAIN_ONLY), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 #endif
 
-  Nan::ForceSet(target,Nan::New<String>("FFI_ARG_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_arg)), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
-  Nan::ForceSet(target,Nan::New<String>("FFI_SARG_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_sarg)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-  Nan::ForceSet(target,Nan::New<String>("FFI_TYPE_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_type)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
-  Nan::ForceSet(target,Nan::New<String>("FFI_CIF_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_cif)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("FFI_ARG_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_arg)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("FFI_SARG_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_sarg)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("FFI_TYPE_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_type)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<String>("FFI_CIF_SIZE").ToLocalChecked(), Nan::New<Uint32>((uint32_t)sizeof(ffi_cif)), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
   bool hasObjc = false;
 #if __OBJC__ || __OBJC2__
   hasObjc = true;
 #endif
-  Nan::ForceSet(target,Nan::New<String>("HAS_OBJC").ToLocalChecked(), Nan::New<Boolean>(hasObjc), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
+  Nan::DefineOwnProperty(target,Nan::New<String>("HAS_OBJC").ToLocalChecked(), Nan::New<Boolean>(hasObjc), static_cast<PropertyAttribute>(ReadOnly | DontDelete));
 
   Local<Object> ftmap = Nan::New<Object>();
   ftmap->Set(Nan::New<String>("void").ToLocalChecked(), WrapPointer((char *)&ffi_type_void));
@@ -364,7 +364,7 @@ void FFI::FinishAsyncFFICall(uv_work_t *req) {
   Nan::TryCatch try_catch;
 
   // invoke the registered callback function
-  p->callback->Call(1, argv);
+  Nan::Call(*p->callback, 1, argv);
 
   // dispose of our persistent handle to the callback function
   delete p->callback;


### PR DESCRIPTION
node-ffi is currently broken on the latest Node (v9.11.1) on latest macOS (10.13.4 17E199). Upgrading nan fixes it. API changes required are using `nan::Call()` instead of member `Call()`, and using `DefineOwnProperty()` instead of `ForceSet()`. 