### PR TITLE
Mention Node 10 support and ffi-napi

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ for an example of this use case.
 create situations where you will segfault the interpreter and unless you've got
 C debugger skills, you probably won't know what's going on.
 
+**NOTE**: node-ffi supports Node 10. For newer versions of Node.js, you may
+want to use [ffi-napi instead](https://www.npmjs.com/package/ffi-napi).
+
 Example
 -------
 


### PR DESCRIPTION
Thank you for an amazing package! I was unable to get this working for a v14 project. I ended up moving to `ffi-napi` for it. I think mentioning this at the top of the README will save folks who are new to FFI on Windows some time.